### PR TITLE
Bump puppetlabs/stdlib dependency in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">=3.3.0 <=4.5.1"
+      "version_requirement": ">=3.3.0 <5.0.0"
     }
   ]
 }


### PR DESCRIPTION
puppetlabs/stdlib is current at 4.6.0, which I've confirmed is compatible